### PR TITLE
feat(nge-monaco): enable config factory to access DI

### DIFF
--- a/projects/demo/src/assets/docs/nge-monaco/usage.md
+++ b/projects/demo/src/assets/docs/nge-monaco/usage.md
@@ -199,7 +199,8 @@ Characters such as &lt;, &gt;, {, } directly written in the HTML template file m
 
 ## Options
 
-Optionally, nge-monaco can be configured by passing **NgeMonacoConfig** object to the forRoot method of **NgeMonacoModule**.
+Optionally, nge-monaco can be configured by passing **NgeMonacoConfig** object to the forRoot method of **NgeMonacoModule** directly
+or as factory function, which allows access to dependency injection via `inject` function.
 
 ```typescript highlights="5 14-29"
 import { NgModule } from '@angular/core';

--- a/projects/nge/monaco/src/monaco.module.ts
+++ b/projects/nge/monaco/src/monaco.module.ts
@@ -20,11 +20,17 @@ import { NgeMonacoPlaceholderComponent } from './components/monaco-placeholder/m
   ],
 })
 export class NgeMonacoModule {
-  static forRoot(config: NgeMonacoConfig): ModuleWithProviders<NgeMonacoModule> {
+  static forRoot(
+    config: NgeMonacoConfig | (() => NgeMonacoConfig)
+  ): ModuleWithProviders<NgeMonacoModule> {
+    const configProvider =
+      typeof config === "function"
+        ? { provide: NGE_MONACO_CONFIG, useFactory: config }
+        : { provide: NGE_MONACO_CONFIG, useValue: config }
     return {
       ngModule: NgeMonacoModule,
       providers: [
-        { provide: NGE_MONACO_CONFIG, useValue: config },
+        configProvider,
         {
           provide: NGE_MONACO_CONTRIBUTION,
           multi: true,


### PR DESCRIPTION
To enable access to the DI, the `NgeMonacoModule.forRoot` now accepts a config factory function.
The DI access can be useful to access external configuration, like the base href from the DI for the `NgeMonacoConfig`.