### PR TITLE
fix(doc): route internal Markdown links through the router

### DIFF
--- a/projects/nge/doc/src/renderer/renderer.component.spec.ts
+++ b/projects/nge/doc/src/renderer/renderer.component.spec.ts
@@ -1,0 +1,70 @@
+import { Location } from '@angular/common'
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { ActivatedRoute, Router } from '@angular/router'
+import { CompilerService } from '@cisstech/nge/services'
+import { Subject } from 'rxjs'
+import { NGE_DOC_RENDERERS } from '../nge-doc'
+import { NgeDocService } from '../nge-doc.service'
+import { NgeDocRendererComponent } from './renderer.component'
+
+// Regression guard: authored Markdown links are plain anchors. Left to the
+// browser they do a full-page load to an absolute path that ignores the
+// deployed base href (so `/nge/` is dropped on GitHub Pages). The renderer must
+// intercept internal links and route them through the Angular router instead.
+describe('NgeDocRendererComponent link handling', () => {
+  let fixture: ComponentFixture<NgeDocRendererComponent>
+  let host: HTMLElement
+  let router: { navigateByUrl: jest.Mock }
+
+  beforeEach(() => {
+    router = { navigateByUrl: jest.fn() }
+    TestBed.configureTestingModule({
+      imports: [NgeDocRendererComponent],
+      providers: [
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: { snapshot: { fragment: null } } },
+        { provide: Location, useValue: { normalize: (url: string) => url, path: () => '/docs/current' } },
+        { provide: NgeDocService, useValue: { stateChanges: new Subject(), currLink: () => null, setSeo: jest.fn() } },
+        { provide: CompilerService, useValue: { render: jest.fn() } },
+        { provide: NGE_DOC_RENDERERS, useValue: { markdown: { component: () => Promise.resolve(class {}) } } },
+      ],
+    })
+    fixture = TestBed.createComponent(NgeDocRendererComponent)
+    fixture.detectChanges()
+    host = fixture.nativeElement as HTMLElement
+  })
+
+  function clickAnchor(attributes: Record<string, string>, init: MouseEventInit = {}): MouseEvent {
+    const anchor = document.createElement('a')
+    Object.entries(attributes).forEach(([key, value]) => anchor.setAttribute(key, value))
+    anchor.textContent = 'link'
+    host.appendChild(anchor)
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0, ...init })
+    anchor.dispatchEvent(event)
+    return event
+  }
+
+  it('routes an internal link through the router and cancels the navigation', () => {
+    const event = clickAnchor({ href: '/docs/nge-markdown/installation' })
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/docs/nge-markdown/installation')
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('leaves links to another origin to the browser', () => {
+    const event = clickAnchor({ href: 'https://example.com/docs/x' })
+    expect(router.navigateByUrl).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('leaves modified clicks alone so the browser can open a new tab', () => {
+    const event = clickAnchor({ href: '/docs/x' }, { metaKey: true })
+    expect(router.navigateByUrl).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('respects links that opt out of internal routing with a target', () => {
+    const event = clickAnchor({ href: '/docs/x', target: '_blank' })
+    expect(router.navigateByUrl).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+  })
+})

--- a/projects/nge/doc/src/renderer/renderer.component.ts
+++ b/projects/nge/doc/src/renderer/renderer.component.ts
@@ -1,3 +1,4 @@
+import { Location } from '@angular/common'
 import { HttpClient } from '@angular/common/http'
 import {
   ChangeDetectionStrategy,
@@ -14,7 +15,7 @@ import {
   signal,
   viewChild,
 } from '@angular/core'
-import { ActivatedRoute } from '@angular/router'
+import { ActivatedRoute, Router } from '@angular/router'
 import { CompilerService } from '@cisstech/nge/services'
 import { Subscription, firstValueFrom } from 'rxjs'
 import { parseFrontmatter } from '../frontmatter'
@@ -36,6 +37,9 @@ export interface NgeDocHeading {
   templateUrl: 'renderer.component.html',
   styleUrls: ['renderer.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '(click)': 'onHostClick($event)',
+  },
 })
 export class NgeDocRendererComponent implements OnInit, OnDestroy {
   private readonly injector = inject(Injector)
@@ -45,6 +49,8 @@ export class NgeDocRendererComponent implements OnInit, OnDestroy {
   private readonly changeDetectorRef = inject(ChangeDetectorRef)
   private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef)
   private readonly activatedRoute = inject(ActivatedRoute)
+  private readonly router = inject(Router)
+  private readonly location = inject(Location)
 
   private subscriptions: Subscription[] = []
   protected readonly loading = signal(false)
@@ -86,6 +92,56 @@ export class NgeDocRendererComponent implements OnInit, OnDestroy {
   scrollToHeading(id: string): void {
     this.headingElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
     this.activeHeadingId.set(id)
+  }
+
+  /**
+   * Routes clicks on internal links through the Angular router. Authored Markdown
+   * links are plain anchors (for example `/docs/getting-started`); left to the
+   * browser they trigger a full-page load to an absolute path that ignores the
+   * deployed `<base href>`, so under a base href such as `/nge/` the segment is
+   * dropped. Routing them keeps navigation in the SPA and re-applies the base href.
+   */
+  protected onHostClick(event: MouseEvent): void {
+    // Let the browser handle modified clicks (new tab, download, ...).
+    if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return
+    }
+
+    const anchor = (event.target as HTMLElement | null)?.closest('a')
+    if (!anchor) {
+      return
+    }
+
+    const target = anchor.getAttribute('target')
+    if ((target && target !== '_self') || anchor.hasAttribute('download')) {
+      return
+    }
+
+    let url: URL
+    try {
+      url = new URL(anchor.href)
+    } catch {
+      return
+    }
+
+    // Leave links to other origins to the browser.
+    if (url.origin !== window.location.origin) {
+      return
+    }
+
+    event.preventDefault()
+
+    // `normalize` strips the base href, giving a path the router understands; the
+    // router re-applies the base href when it updates the address bar.
+    const path = this.location.normalize(url.pathname)
+    const fragment = url.hash.replace(/^#/, '')
+
+    if (fragment && path === this.location.path().split('?')[0]) {
+      this.scrollToHeading(fragment)
+      return
+    }
+
+    this.router.navigateByUrl(path + url.search + url.hash)
   }
 
   private showLoading(): void {


### PR DESCRIPTION
Authored Markdown links are plain anchors (for example `/docs/getting-started`). Left to the browser they trigger a full-page load to an absolute path, which ignores `<base href>`, so on GitHub Pages served under `/nge/` the segment was dropped and the link 404'd (cisstech.github.io/docs/... instead of cisstech.github.io/nge/docs/...).

The renderer now intercepts clicks on same-origin anchors and routes them through the Angular router, which re-applies the base href and keeps navigation inside the SPA. Modified clicks, downloads, `target` links and cross-origin links are left to the browser. Covered by a new renderer spec.