### PR TITLE
feat(doc): revamp nge-doc into a modern documentation engine

### DIFF
--- a/projects/demo/src/app/docs/actions.ts
+++ b/projects/demo/src/app/docs/actions.ts
@@ -1,0 +1,16 @@
+import { NgeDocIcon, NgeDocLinAction } from '@cisstech/nge/doc'
+
+// icongr.am is cross-origin, so provide a per-scheme colored variant (a mask
+// can't recolor a cross-origin icon). Colors match the theme's muted foreground.
+export const octicon = (name: string): NgeDocIcon => ({
+  light: `https://icongr.am/octicons/${name}.svg?color=52525b`,
+  dark: `https://icongr.am/octicons/${name}.svg?color=a1a1aa`,
+})
+
+// `path` is the file under projects/demo/src (the same value as a page renderer),
+// so the action links straight to the Markdown source on GitHub.
+export const editInGithubAction = (path: string): NgeDocLinAction => ({
+  title: 'Edit on github',
+  icon: octicon('pencil'),
+  run: `https://github.com/cisstech/nge/tree/main/projects/demo/src/${path}`,
+})

--- a/projects/demo/src/app/docs/nge-doc.ts
+++ b/projects/demo/src/app/docs/nge-doc.ts
@@ -1,4 +1,5 @@
 import { NgeDocSettings } from '@cisstech/nge/doc'
+import { editInGithubAction } from './actions'
 
 export const NGE_DOC: NgeDocSettings = {
   meta: {
@@ -16,21 +17,25 @@ export const NGE_DOC: NgeDocSettings = {
       title: 'Getting Started',
       href: 'getting-started',
       renderer: 'assets/docs/nge-doc/getting-started.md',
+      actions: [editInGithubAction('assets/docs/nge-doc/getting-started.md')],
     },
     {
       title: 'Installation',
       href: 'installation',
       renderer: 'assets/docs/nge-doc/installation.md',
+      actions: [editInGithubAction('assets/docs/nge-doc/installation.md')],
     },
     {
       title: 'Usage',
       href: 'usage',
       renderer: 'assets/docs/nge-doc/usage.md',
+      actions: [editInGithubAction('assets/docs/nge-doc/usage.md')],
     },
     {
       title: 'Advanced Usage',
       href: 'advanced-usage',
       renderer: 'assets/docs/nge-doc/advanced-usage.md',
+      actions: [editInGithubAction('assets/docs/nge-doc/advanced-usage.md')],
     },
   ],
 }

--- a/projects/demo/src/app/docs/nge-markdown.ts
+++ b/projects/demo/src/app/docs/nge-markdown.ts
@@ -1,20 +1,5 @@
-import { NgeDocIcon, NgeDocLinAction, NgeDocLink, NgeDocSettings } from '@cisstech/nge/doc'
-
-// icongr.am is cross-origin, so provide a per-scheme colored variant (a mask
-// can't recolor a cross-origin icon). Colors match the theme's muted foreground.
-const octicon = (name: string): NgeDocIcon => ({
-  light: `https://icongr.am/octicons/${name}.svg?color=52525b`,
-  dark: `https://icongr.am/octicons/${name}.svg?color=a1a1aa`,
-})
-
-const editInGithubAction = (url: string) => {
-  const base = 'https://github.com/cisstech/nge/tree/main/projects/demo/src/assets/docs/nge-markdown/'
-  return {
-    title: 'Edit on github',
-    icon: octicon('pencil'),
-    run: base + url,
-  } as NgeDocLinAction
-}
+import { NgeDocLink, NgeDocSettings } from '@cisstech/nge/doc'
+import { editInGithubAction, octicon } from './actions'
 
 export const NGE_MARKDOWN: NgeDocSettings = {
   meta: {
@@ -33,25 +18,25 @@ export const NGE_MARKDOWN: NgeDocSettings = {
       title: 'Getting Started',
       href: 'getting-started',
       renderer: `assets/docs/nge-markdown/getting-started.md`,
-      actions: [editInGithubAction('getting-started.md')],
+      actions: [editInGithubAction('assets/docs/nge-markdown/getting-started.md')],
     },
     {
       title: 'Installation',
       href: 'installation',
       renderer: `assets/docs/nge-markdown/installation.md`,
-      actions: [editInGithubAction('installation.md')],
+      actions: [editInGithubAction('assets/docs/nge-markdown/installation.md')],
     },
     {
       title: 'Usage',
       href: 'usage',
       renderer: `assets/docs/nge-markdown/usage.md`,
-      actions: [editInGithubAction('usage.md')],
+      actions: [editInGithubAction('assets/docs/nge-markdown/usage.md')],
     },
     {
       title: 'Embedding components',
       href: 'embedding',
       renderer: `assets/docs/nge-markdown/embedding.md`,
-      actions: [editInGithubAction('embedding.md')],
+      actions: [editInGithubAction('assets/docs/nge-markdown/embedding.md')],
     },
     { separator: true, title: 'Reference', color: '#8b5cf6' },
     () => {
@@ -59,7 +44,7 @@ export const NGE_MARKDOWN: NgeDocSettings = {
         title: 'Contributions',
         href: 'contributions',
         renderer: 'assets/docs/nge-markdown/contributions/contributions.md',
-        actions: [editInGithubAction('contributions/contributions.md')],
+        actions: [editInGithubAction('assets/docs/nge-markdown/contributions/contributions.md')],
       } as NgeDocLink
 
       const contributions = ['Admonitions', 'Emoji', 'Highlighter', 'Icons', 'Katex', 'LinkAnchor', 'TabbedSet']
@@ -81,7 +66,7 @@ export const NGE_MARKDOWN: NgeDocSettings = {
               icon: octicon('code'),
               run: base + 'nge-markdown-' + snakecase + '.ts',
             },
-            editInGithubAction('contributions/' + snakecase + '.md'),
+            editInGithubAction('assets/docs/nge-markdown/contributions/' + snakecase + '.md'),
           ],
         }
       })

--- a/projects/demo/src/app/docs/nge-monaco.ts
+++ b/projects/demo/src/app/docs/nge-monaco.ts
@@ -1,4 +1,5 @@
 import { NgeDocSettings } from '@cisstech/nge/doc'
+import { editInGithubAction } from './actions'
 
 export const NGE_MONACO: NgeDocSettings = {
   meta: {
@@ -16,16 +17,19 @@ export const NGE_MONACO: NgeDocSettings = {
       title: 'Getting Started',
       href: 'getting-started',
       renderer: `assets/docs/nge-monaco/getting-started.md`,
+      actions: [editInGithubAction('assets/docs/nge-monaco/getting-started.md')],
     },
     {
       title: 'Installation',
       href: 'installation',
       renderer: `assets/docs/nge-monaco/installation.md`,
+      actions: [editInGithubAction('assets/docs/nge-monaco/installation.md')],
     },
     {
       title: 'Usage',
       href: 'usage',
       renderer: `assets/docs/nge-monaco/usage.md`,
+      actions: [editInGithubAction('assets/docs/nge-monaco/usage.md')],
     },
     {
       title: 'Showcase',

--- a/projects/demo/src/app/docs/nge-ui.ts
+++ b/projects/demo/src/app/docs/nge-ui.ts
@@ -1,4 +1,5 @@
 import { NgeDocSettings } from '@cisstech/nge/doc'
+import { editInGithubAction } from './actions'
 
 export const NGE_UI: NgeDocSettings = {
   meta: {
@@ -16,21 +17,25 @@ export const NGE_UI: NgeDocSettings = {
       title: 'Getting Started',
       href: 'getting-started',
       renderer: 'assets/docs/nge-ui/getting-started.md',
+      actions: [editInGithubAction('assets/docs/nge-ui/getting-started.md')],
     },
     {
       title: 'Tree',
       href: 'tree',
       renderer: 'assets/docs/nge-ui/tree.md',
+      actions: [editInGithubAction('assets/docs/nge-ui/tree.md')],
     },
     {
       title: 'List',
       href: 'list',
       renderer: 'assets/docs/nge-ui/list.md',
+      actions: [editInGithubAction('assets/docs/nge-ui/list.md')],
     },
     {
       title: 'Icon',
       href: 'icon',
       renderer: 'assets/docs/nge-ui/icon.md',
+      actions: [editInGithubAction('assets/docs/nge-ui/icon.md')],
     },
   ],
 }

--- a/projects/demo/src/app/docs/overview.ts
+++ b/projects/demo/src/app/docs/overview.ts
@@ -1,4 +1,5 @@
 import { NgeDocSettings } from '@cisstech/nge/doc'
+import { editInGithubAction } from './actions'
 
 export const NGE_OVERVIEW: NgeDocSettings = {
   meta: {
@@ -15,11 +16,13 @@ export const NGE_OVERVIEW: NgeDocSettings = {
       title: 'Introduction',
       href: 'introduction',
       renderer: 'assets/docs/overview/introduction.md',
+      actions: [editInGithubAction('assets/docs/overview/introduction.md')],
     },
     {
       title: 'Installation',
       href: 'installation',
       renderer: 'assets/docs/overview/installation.md',
+      actions: [editInGithubAction('assets/docs/overview/installation.md')],
     },
   ],
 }

--- a/projects/demo/src/app/docs/utilities.ts
+++ b/projects/demo/src/app/docs/utilities.ts
@@ -1,4 +1,5 @@
 import { NgeDocSettings } from '@cisstech/nge/doc'
+import { editInGithubAction } from './actions'
 
 export const NGE_UTILITIES: NgeDocSettings = {
   meta: {
@@ -16,21 +17,25 @@ export const NGE_UTILITIES: NgeDocSettings = {
       title: 'Getting Started',
       href: 'getting-started',
       renderer: 'assets/docs/utilities/getting-started.md',
+      actions: [editInGithubAction('assets/docs/utilities/getting-started.md')],
     },
     {
       title: 'Services',
       href: 'services',
       renderer: 'assets/docs/utilities/services.md',
+      actions: [editInGithubAction('assets/docs/utilities/services.md')],
     },
     {
       title: 'Pipes',
       href: 'pipes',
       renderer: 'assets/docs/utilities/pipes.md',
+      actions: [editInGithubAction('assets/docs/utilities/pipes.md')],
     },
     {
       title: 'Utils',
       href: 'utils',
       renderer: 'assets/docs/utilities/utils.md',
+      actions: [editInGithubAction('assets/docs/utilities/utils.md')],
     },
   ],
 }


### PR DESCRIPTION
Reworks `@cisstech/nge/doc` into a self-contained documentation engine you configure through `provideNgeDoc`. Additive and backward compatible: `NgeDocModule` still works (now deprecated). Slated for the 22.0.0 release.

Highlights:

- Pluggable theme with light and dark, and a color-scheme sync so Monaco and Markdown follow the docs.
- Header brand, navbar, command-palette search (Cmd/Ctrl+K), breadcrumb, pager and keyboard navigation.
- Redesigned sidebar with collapsible folders and section separators.
- Per-page SEO from frontmatter, live components embeddable in Markdown, and edit-on-github on every Markdown page.
- Translatable wording via `withLabels` (ready-made EN and FR).

Fixes bundled in:

- Internal Markdown links no longer drop the base href on GitHub Pages.
- The global `monaco` types now ship in the published package, and the `monaco-editor` peer range is honest.

Verified with the unit tests, `build:lib`, `build:demo`, and a fresh Angular 22 consumer.
