### PR TITLE
fix(release): push the release tag so the GitHub release can be created

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -53,8 +53,9 @@ jobs:
           git checkout -b release/v$VERSION
           git add package.json CHANGELOG.md
           git commit -m "[no-ci] chore(release): v$VERSION"
-          git tag v$VERSION
-          git push --follow-tags origin release/v$VERSION
+          git tag -a v$VERSION -m "v$VERSION"
+          git push origin release/v$VERSION
+          git push origin "v$VERSION"
           gh pr create --title "Release: v$VERSION" --body "Automated release: updated package.json and CHANGELOG for v$VERSION." --base main --head release/v$VERSION
 
       - name: Publish GitHub release


### PR DESCRIPTION
The v22.1.0 release run failed at the *Publish GitHub release* step with: `tag v22.1.0 exists locally but has not been pushed`.

Cause: the workflow created a **lightweight** tag with `git tag` and pushed with `git push --follow-tags`, which only pushes **annotated** tags. So the tag was never pushed, and `gh release create` could not find it. (The old `actions/create-release@v1` step created the tag itself, which hid this.)

Fix: create an annotated tag and push it explicitly.

The bump and changelog generation worked correctly in that run; only the tag push was missing.