### PR TITLE
fix(release): deepen release checkout and run post-build version sync

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -32,6 +32,8 @@ jobs:
       pull-requests: write  # Permission to create pull requests
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "yarn build:lib && yarn build:demo",
-    "build:lib": "ng build nge --configuration production",
+    "build:lib": "ng build nge --configuration production && yarn postbuild:lib",
     "postbuild:lib": "./scripts/postbuild.sh && yarn sync-version",
     "build:demo": "ng build demo --configuration production --base-href='https://cisstech.github.io/nge/'",
     "test": "jest --coverage=true --watch=false --coverageReporters=lcov  --browsers=ChromeHeadless && node coverage-merger.js",


### PR DESCRIPTION
Follow-up to the v22.1.0 release attempt, which produced an empty changelog and failed `npm publish` with version 0.0.0.

**1. Empty changelog** - the publish job checked out shallow (`fetch-depth: 1`, no tags), so `standard-version` had no history or tags and generated an empty section (the fix commits exist but were invisible to it). Now checks out with `fetch-depth: 0`.

**2. npm publish 0.0.0** - Yarn 4 (Berry) does not run `pre`/`post` script hooks, so `postbuild:lib` (which runs `sync-version`) never fired and `dist/nge/package.json` kept its placeholder `0.0.0`. `build:lib` now runs `postbuild:lib` explicitly.

Verified locally: after `yarn build:lib`, `dist/nge/package.json` carries the real version.