### PR TITLE
ci: publish to npm before tagging + bump action runtimes to v5

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,6 +12,10 @@ runs:
     - uses: actions/setup-node@v5
       with:
         node-version: ${{ inputs.node-version }}
+        # Yarn is Corepack-managed and enabled in the next step; setup-node's own
+        # dependency cache probes yarn too early (global yarn 1 vs packageManager
+        # yarn 4) and fails, so leave it off. Yarn's global cache covers this.
+        package-manager-cache: false
     - name: Enable Corepack
       shell: bash
       run: corepack enable

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v5
       with:
         node-version: ${{ inputs.node-version }}
     - name: Enable Corepack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       name: Prepare
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - uses: ./.github/actions/setup
           with:
             node-version: ${{ env.NODE_VERSION }}
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish-ghpages.yml
+++ b/.github/workflows/publish-ghpages.yml
@@ -13,7 +13,7 @@ jobs:
       name: Prepare
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - uses: ./.github/actions/setup
           with:
             node-version: ${{ env.NODE_VERSION }}
@@ -25,7 +25,7 @@ jobs:
       contents: write  # Write access to repository content
       pages: write  # Write access to publish pages
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -17,7 +17,7 @@ jobs:
       name: Prepare
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - uses: ./.github/actions/setup
           with:
             node-version: ${{ env.NODE_VERSION }}
@@ -31,7 +31,7 @@ jobs:
       id-token: write  # Permission to create releases
       pull-requests: write  # Permission to create pull requests
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
@@ -45,33 +45,34 @@ jobs:
 
       - name: Bump version and generate changelog
         id: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npx standard-version --skip.commit --skip.tag --release-as ${{ inputs.version }}
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           awk '/^#{2,3} \[?[0-9]+\.[0-9]+\.[0-9]+/{c++} c==1{print} c==2{exit}' CHANGELOG.md > RELEASE_NOTES.md
-          git checkout -b release/v$VERSION
-          git add package.json CHANGELOG.md
-          git commit -m "[no-ci] chore(release): v$VERSION"
-          git tag -a v$VERSION -m "v$VERSION"
-          git push origin release/v$VERSION
-          git push origin "v$VERSION"
-          gh pr create --title "Release: v$VERSION" --body "Automated release: updated package.json and CHANGELOG for v$VERSION." --base main --head release/v$VERSION
 
-      - name: Publish GitHub release
-        if: success()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create v${{ steps.release.outputs.version }} --title "v${{ steps.release.outputs.version }}" --notes-file RELEASE_NOTES.md
-
-      - name: Publish to npm
-        if: success()
+      # npm publish is the one step that is hard to undo, so it runs first.
+      # If it fails, the tag / branch / GitHub release / PR below are skipped
+      # and nothing points at a version that is not on npm.
+      - name: Build and publish to npm
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_PUBLIC_TOKEN }}" > ~/.npmrc
           yarn build:lib
           npm publish ./dist/nge --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLIC_TOKEN }}
-        shell: bash
+
+      - name: Tag, push and publish the GitHub release
+        if: success()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=${{ steps.release.outputs.version }}
+          git checkout -b release/v$VERSION
+          git add package.json CHANGELOG.md
+          git commit -m "[no-ci] chore(release): v$VERSION"
+          git tag -a v$VERSION -m "v$VERSION"
+          git push origin release/v$VERSION
+          git push origin "v$VERSION"
+          gh release create v$VERSION --title "v$VERSION" --notes-file RELEASE_NOTES.md
+          gh pr create --title "Release: v$VERSION" --body "Automated release for v$VERSION (already published to npm and released on GitHub in this run). Merges the version bump and CHANGELOG into main." --base main --head release/v$VERSION


### PR DESCRIPTION
## Summary

Two hardening changes to the release pipeline.

### npm-first release order
`publish-npm` used to push the release branch, open the PR and create the GitHub release **before** running `npm publish`. A failed publish left a tag, a PR and a GitHub release pointing at a version that was never on npm. Now the build + `npm publish` runs first, and the tag, branch push, GitHub release and PR only run if it succeeds.

### Node 24 runtimes
Bump `actions/checkout`, `actions/setup-node` and `codecov-action` to v5 to clear the "Node.js 20 is deprecated" runtime warning.