### PR TITLE
feat(monaco,markdown): accept an array of darkThemeClassName values

### DIFF
--- a/projects/demo/src/assets/docs/nge-doc/advanced-usage.md
+++ b/projects/demo/src/assets/docs/nge-doc/advanced-usage.md
@@ -112,8 +112,10 @@ The default theme ships a light/dark toggle. Set the initial scheme with `withDa
 
 `NgeDocThemeService` owns the scheme: read `isDark()`, call `toggle()` or `setScheme()`, and it
 reflects the result as a `nge-doc-dark` class on the document root while the docs are on screen.
-Other libraries can follow that class; for example `nge/monaco` can switch its editor theme
-through its `theming.darkThemeClassName` option.
+Other libraries can follow that class: point [nge/monaco](/docs/nge-monaco/usage) and
+[nge/markdown](/docs/nge-markdown/usage) at `darkThemeClassName: 'nge-doc-dark'` and their editors
+and rendered Markdown switch with the site. Both options also accept an array, so a page that
+toggles its own dark class as well can pass `['dark-theme', 'nge-doc-dark']`.
 
 ## Search
 

--- a/projects/demo/src/assets/docs/nge-markdown/usage.md
+++ b/projects/demo/src/assets/docs/nge-markdown/usage.md
@@ -169,6 +169,11 @@ variant when that class is present on `<html>` or `<body>`.
 NgeMarkdownConfigProvider({ darkThemeClassName: 'dark-theme' })
 ```
 
+Inside an [nge/doc](/docs/nge-doc/getting-started) site, use its class:
+`darkThemeClassName: 'nge-doc-dark'`. This is the same option as in
+[nge/monaco](/docs/nge-monaco/usage), so one class drives both. It also accepts an array
+(`['dark-theme', 'nge-doc-dark']`) for apps whose pages toggle different dark classes.
+
 ## Compile Markdown yourself
 
 `NgeMarkdownComponent` wraps `NgeMarkdownService`. Inject the service to render into an element

--- a/projects/demo/src/assets/docs/nge-monaco/usage.md
+++ b/projects/demo/src/assets/docs/nge-monaco/usage.md
@@ -215,6 +215,11 @@ This is how these docs keep the editors in step with the site: nge/doc toggles a
 mode, and Monaco reads the same class. `darkThemeClassName` matches the option of the same name in
 [nge/markdown](/docs/nge-markdown/usage), so a single class drives both.
 
+Inside an [nge/doc](/docs/nge-doc/getting-started) site, set `darkThemeClassName: 'nge-doc-dark'`,
+the class nge/doc toggles on `<html>`. `darkThemeClassName` also accepts an array, so an app whose
+pages use different dark classes can pass `['dark-theme', 'nge-doc-dark']` and Monaco follows
+whichever one is present.
+
 ## Extensions
 
 Register a contribution to run code once Monaco is available, for example to add a language. Bind

--- a/projects/nge/markdown/src/nge-markdown-config.ts
+++ b/projects/nge/markdown/src/nge-markdown-config.ts
@@ -6,9 +6,10 @@ import { MarkedOptions } from 'marked'
  */
 export declare type NgeMarkdownConfig = MarkedOptions & {
   /**
-   * Class name indicating that the page is currently in dark mode
+   * Class name (or names) indicating that the page is currently in dark mode.
+   * Pass an array to match any of several dark classes across a multi-page app.
    */
-  darkThemeClassName?: string
+  darkThemeClassName?: string | string[]
 }
 
 /**

--- a/projects/nge/markdown/src/nge-markdown.component.ts
+++ b/projects/nge/markdown/src/nge-markdown.component.ts
@@ -151,9 +151,10 @@ export class NgeMarkdownComponent implements OnInit, AfterViewInit, OnDestroy {
     const { darkThemeClassName } = this.markdownService.config
     if (darkThemeClassName) {
       // TODO: support angular universal
-      this.isDark =
-        document.querySelector(darkThemeClassName.startsWith('.') ? darkThemeClassName : `.${darkThemeClassName}`) !=
-        null
+      const classNames = Array.isArray(darkThemeClassName) ? darkThemeClassName : [darkThemeClassName]
+      this.isDark = classNames.some(
+        (name) => document.querySelector(name.startsWith('.') ? name : `.${name}`) != null
+      )
     }
   }
 

--- a/projects/nge/monaco/src/monaco-config.ts
+++ b/projects/nge/monaco/src/monaco-config.ts
@@ -37,14 +37,15 @@ export interface NgeMonacoConfig {
     dark?: string
     /**
      * How dark mode is detected for automatic switching:
-     * - a class name that means "dark" when present on the document root
-     *   (e.g. `nge-doc-dark` or `dark`), observed live
+     * - a class name (or an array of class names) that means "dark" when present
+     *   on the document root (e.g. `nge-doc-dark` or `dark`), observed live. Pass
+     *   an array to match any of several dark classes across a multi-page app.
      * - omit to follow the `(prefers-color-scheme: dark)` media query
      *
      * Named to mirror `NgeMarkdownConfig.darkThemeClassName` so both libraries
      * read the same class.
      */
-    darkThemeClassName?: string
+    darkThemeClassName?: string | string[]
   }
 }
 

--- a/projects/nge/monaco/src/services/monaco-theme.service.ts
+++ b/projects/nge/monaco/src/services/monaco-theme.service.ts
@@ -70,18 +70,27 @@ export class NgeMonacoThemeService implements NgeMonacoContribution {
    * class is given, the `(prefers-color-scheme: dark)` media query. This is how
    * an app (or nge-doc) drives Monaco's theme without any coupling.
    */
-  private async startColorSchemeSync(light: string, dark: string, darkThemeClassName?: string): Promise<void> {
+  private async startColorSchemeSync(
+    light: string,
+    dark: string,
+    darkThemeClassName?: string | string[]
+  ): Promise<void> {
     const doc = this.document
     const media = doc.defaultView?.matchMedia?.('(prefers-color-scheme: dark)')
-    // Apps put the dark class on <html> or <body>, so check both roots.
-    const hasDarkClass = (cls: string) =>
-      doc.documentElement.classList.contains(cls) || !!doc.body?.classList.contains(cls)
-    const isDark = () => (darkThemeClassName ? hasDarkClass(darkThemeClassName) : !!media?.matches)
+    const classNames = darkThemeClassName
+      ? Array.isArray(darkThemeClassName)
+        ? darkThemeClassName
+        : [darkThemeClassName]
+      : []
+    // Apps put the dark class on <html> or <body>, so check both roots for any of the names.
+    const hasDarkClass = () =>
+      classNames.some((cls) => doc.documentElement.classList.contains(cls) || !!doc.body?.classList.contains(cls))
+    const isDark = () => (classNames.length ? hasDarkClass() : !!media?.matches)
     const apply = () => this.setTheme(isDark() ? dark : light).catch(() => undefined)
 
     await apply()
 
-    if (darkThemeClassName) {
+    if (classNames.length) {
       this.colorSchemeObserver?.disconnect()
       this.colorSchemeObserver = new MutationObserver(() => apply())
       const options: MutationObserverInit = { attributes: true, attributeFilter: ['class'] }


### PR DESCRIPTION
## Summary

`darkThemeClassName` in **nge/monaco** and **nge/markdown** now accepts `string | string[]`. An application whose pages toggle different dark classes can match any of them, while a single string keeps working unchanged.

The motivating case: a site that embeds both an nge/doc documentation area (which toggles `nge-doc-dark`) and another surface with its own dark class (for example an app shell). Passing `['dark-theme', 'nge-doc-dark']` lets the editor and rendered Markdown follow whichever class is currently present.

## Changes

- `NgeMonacoConfig.theming.darkThemeClassName`: `string | string[]`; the theme service normalizes to an array and its live `MutationObserver` matches any of the names on `<html>`/`<body>`.
- `NgeMarkdownConfig.darkThemeClassName`: `string | string[]`; the component matches any of the names.
- Docs: the nge/monaco, nge/markdown and nge/doc pages now cross-reference the option and recommend `nge-doc-dark` when combining with nge/doc.

Backward compatible (string is still accepted). Verified: `build:lib`, `lint`, tests pass.