### PR TITLE
fix(markdown): stop parsing LaTeX display math as markdown (#335)

### DIFF
--- a/projects/nge/markdown/src/contributions/nge-markdown-katex.ts
+++ b/projects/nge/markdown/src/contributions/nge-markdown-katex.ts
@@ -62,9 +62,32 @@ export class NgeMarkdownKatex implements NgeMarkdownContribution {
   }
 
   contribute(transformer: NgeMarkdownTransformer) {
-    // pattern to search multiline latex between $$...$$ or inline latex between $...$
-    // const pattern = /(\$\$\n((.|\s|\n)+?)\n\$\$)|(\$([^\s][^$\n]+?[^\s])\$)/gm;
+    // Display math ($$...$$ and \[...\]) spans several lines, so protect it from
+    // the markdown parser before lexing. Otherwise a line that starts with "- "
+    // (a negative term in an equation, for instance) is turned into a bullet list
+    // before KaTeX ever sees it. Each block is stashed and restored verbatim just
+    // before rendering. See https://github.com/cisstech/nge/issues/335.
+    const mathBlocks: string[] = []
+    transformer.addMarkdownTransformer((markdown) =>
+      // The first branch matches (and preserves) fenced or inline code, so a `$$`
+      // shown as an example inside code is left untouched.
+      markdown.replace(
+        /(```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]*`)|(\$\$[\s\S]+?\$\$|\\\[[\s\S]+?\\\])/g,
+        (match, code: string | undefined, math: string | undefined) => {
+          if (code != null) return code
+          const index = mathBlocks.push(math as string) - 1
+          return `\n\n<div class="nge-markdown-math" data-math="${index}"></div>\n\n`
+        }
+      )
+    )
+
     transformer.addHtmlTransformer((element) => {
+      element.querySelectorAll<HTMLElement>('.nge-markdown-math').forEach((placeholder) => {
+        const holder = element.ownerDocument.createElement('div')
+        holder.textContent = mathBlocks[Number(placeholder.dataset['math'])] ?? ''
+        placeholder.replaceWith(holder)
+      })
+
       const { renderMathInElement } = window as any
       try {
         renderMathInElement(


### PR DESCRIPTION
## Problem

Inside a display-math block (`$$...$$` or `\[...\]`), a line that starts with `- ` (a negative term in an equation) was rendered as a **bullet list**. KaTeX renders math as an HTML transformer, i.e. *after* marked has already parsed the source, so marked turned those lines into `<ul><li>` before KaTeX ever ran.

## Fix

Protect display-math blocks *before* lexing and restore them verbatim right before KaTeX renders them. Fenced and inline code are matched first and left untouched, so a `$$` shown as an example inside code is preserved. The rendering engine (`renderMathInElement` with its delimiters, mhchem and copy-tex extensions) is unchanged.

## Verified

- Repro input (`\begin{cases}` with `- x + y` lines) no longer produces a list; the block is stored and restored for KaTeX.
- Code fences and inline `$$` examples are left intact.
- `build:lib`, `lint`, tests pass.

Closes #335