### PR TITLE
Fix/nge doc 22.4.1

### DIFF
--- a/projects/demo/public/docs/nge-doc/guides/playground.md
+++ b/projects/demo/public/docs/nge-doc/guides/playground.md
@@ -15,6 +15,12 @@ toolbar gains an "Open in StackBlitz" action. The snippet is injected into the
 project scaffold you configure, so the example runs exactly as you set it up (no
 fragile generation).
 
+`@stackblitz/sdk` is an optional peer, install it only for this feature:
+
+```bash
+npm i @stackblitz/sdk
+```
+
 ```typescript
 import { provideNgeMarkdown, withShiki, withStackblitz } from '@cisstech/nge/markdown'
 
@@ -41,8 +47,7 @@ console.log(greeting)
 ```
 
 For a full app, use `template: 'node'` and provide a `package.json` (and any
-other files) through the `files` option; the snippet lands at `file`. It needs
-the optional `@stackblitz/sdk` dependency.
+other files) through the `files` option; the snippet lands at `file`.
 
 ## Embed a live component
 

--- a/projects/demo/public/docs/nge-markdown/contributions/highlighter.md
+++ b/projects/demo/public/docs/nge-markdown/contributions/highlighter.md
@@ -29,7 +29,9 @@ language falls back to plain text.
 
 The fence options below (`lines`, `highlights`, `filename`) work with both highlighters,
 with the same syntax, and every block gets the same chrome: a toolbar with the filename
-(or the language), a copy action and a download action.
+(or the language), a copy action and a download action. Add `withStackblitz()` and that
+toolbar also gains an "Open in StackBlitz" action on flagged blocks, see the
+[Playground](/docs/nge-doc/guides/playground) guide.
 
 
 Highlight fenced code blocks. The contribution is highlighter-agnostic: it delegates to a service

--- a/projects/nge/doc/schematics/ng-add/index.spec.ts
+++ b/projects/nge/doc/schematics/ng-add/index.spec.ts
@@ -106,4 +106,21 @@ describe('ng-add', () => {
 
     expect(result.exists('/public/docs/index.md')).toBe(true)
   })
+
+  it('completes when provideNgeDoc cannot be wired automatically (build target the utility rejects)', async () => {
+    // The utility resolves the app entry from the build target; without one it
+    // throws on execution, as it does against an Nx workspace it cannot read.
+    const seeded = workspace()
+    const ws = JSON.parse(seeded.read('/angular.json')!.toString())
+    delete ws.projects.app.architect.build
+    seeded.overwrite('/angular.json', JSON.stringify(ws))
+
+    const result = await run(seeded)
+
+    expect(result.exists('/public/docs/index.md')).toBe(true)
+    expect(JSON.parse(result.readContent('/angular.json')).projects.app.architect.docs.builder).toBe(
+      '@cisstech/nge:docs'
+    )
+    expect(result.readContent('/src/app/app.config.ts')).not.toContain('provideNgeDoc')
+  })
 })

--- a/projects/nge/doc/schematics/ng-add/index.ts
+++ b/projects/nge/doc/schematics/ng-add/index.ts
@@ -1,4 +1,4 @@
-import { Rule, SchematicContext, Tree, chain, noop } from '@angular-devkit/schematics'
+import { Rule, SchematicContext, Tree, callRule, chain, noop } from '@angular-devkit/schematics'
 
 interface Schema {
   project?: string
@@ -125,11 +125,14 @@ function addDocsTarget(project: TargetProject): Rule {
 
 /**
  * Best-effort: the official standalone utility handles `app.config.ts` and
- * inline `bootstrapApplication` setups. Anything else (NgModule apps, missing
- * @schematics/angular) falls back to the printed instructions.
+ * inline `bootstrapApplication` setups. Anything it cannot handle (NgModule apps,
+ * missing @schematics/angular, or an Nx workspace whose synthesized build target
+ * the utility rejects) is caught and falls back to the printed instructions.
+ * The rule is executed here, inside the guard, because addRootProvider fails on
+ * execution rather than construction.
  */
 function addRootProviders(projectName: string): Rule {
-  return (tree: Tree, context: SchematicContext) => {
+  return async (tree: Tree, context: SchematicContext) => {
     try {
       // Resolved at run time inside the CLI, where @schematics/angular is present.
       // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -142,8 +145,18 @@ function addRootProviders(projectName: string): Rule {
           }) => unknown
         ) => Rule
       }
-      return addRootProvider(projectName, ({ code, external }) => {
+      const rule = addRootProvider(projectName, ({ code, external }) => {
         return code`${external('provideNgeDoc', '@cisstech/nge/doc')}()`
+      })
+      // Run it here so an execution failure is caught; awaited via a plain
+      // subscribe to sidestep the two rxjs copies the devkit ships with.
+      return await new Promise<Tree>((resolve, reject) => {
+        let result: Tree = tree
+        callRule(rule, tree, context).subscribe({
+          next: (next) => (result = next),
+          error: reject,
+          complete: () => resolve(result),
+        })
       })
     } catch {
       context.logger.warn('Could not add provideNgeDoc() automatically; add it to your providers (printed below).')

--- a/projects/nge/markdown/src/contributions/nge-markdown-highlighter.ts
+++ b/projects/nge/markdown/src/contributions/nge-markdown-highlighter.ts
@@ -2,16 +2,39 @@ import { DOCUMENT, Injector, InjectionToken, Injectable, Provider, Type, inject 
 import { NgeMarkdownTransformer } from '../nge-markdown-transformer'
 import { NgeMarkdownContribution, NGE_MARKDOWN_CONTRIBUTION } from '../nge-markdown-contribution'
 import { CodeAction, applyCodeChrome } from './code-chrome'
-import { NGE_MARKDOWN_STACKBLITZ, openInStackblitz } from './nge-markdown-stackblitz'
 
 const DATA_LINES = 'data-nge-md-hl-lines'
 const DATA_LANGUAGE = 'data-nge-md-hl-language'
 const DATA_HIGHLIGHTS = 'data-nge-md-hl-highlights'
 const DATA_FILENAME = 'data-nge-md-hl-filename'
-const DATA_STACKBLITZ = 'data-nge-md-hl-stackblitz'
 
-const STACKBLITZ_SVG =
-  '<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M10.5 13.5H4.5L14 2l-.5 8.5h6L10 22z"/></svg>'
+/** Fence flag exposed on the rendered `pre`, e.g. from ```ts stackblitz. */
+export const DATA_STACKBLITZ = 'data-nge-md-hl-stackblitz'
+
+/** Context handed to a code-action provider for one highlighted block. */
+export interface NgeMarkdownCodeActionContext {
+  /** The rendered `pre` element, carrying the fence flags as data attributes. */
+  pre: HTMLElement
+  /** The raw code, captured before colorizing mutates the DOM. */
+  code: string
+  /** Fence language. */
+  language: string
+  /** Fence filename, if any. */
+  filename?: string
+}
+
+/**
+ * Contributes a toolbar action to a highlighted code block, or `null` to skip
+ * it. Register with `multi: true` on {@link NGE_MARKDOWN_CODE_ACTIONS}. Keeping
+ * actions behind this token lets optional integrations (StackBlitz, ...) stay
+ * out of the highlighter's module graph until their feature is opted into.
+ */
+export type NgeMarkdownCodeActionProvider = (context: NgeMarkdownCodeActionContext) => CodeAction | null
+
+/** Multi-provider token for code-block toolbar actions. */
+export const NGE_MARKDOWN_CODE_ACTIONS = new InjectionToken<readonly NgeMarkdownCodeActionProvider[]>(
+  'NGE_MARKDOWN_CODE_ACTIONS'
+)
 
 /**
  * Highlight options.
@@ -155,7 +178,7 @@ export class NgeMarkdownHighlighter implements NgeMarkdownContribution {
       return
     }
     const highlight = this.options.highligtht
-    const stackblitz = this.injector.get(NGE_MARKDOWN_STACKBLITZ, null)
+    const actionProviders = this.injector.get(NGE_MARKDOWN_CODE_ACTIONS, [])
     transformer.addHtmlTransformer(async (element) => {
       // Unless the service declares itself server-capable, colorizing waits for
       // the browser: blocks render plain under SSR and colorize after hydration.
@@ -180,14 +203,10 @@ export class NgeMarkdownHighlighter implements NgeMarkdownContribution {
           filename: filename || '',
         })
 
-        const actions: CodeAction[] = []
-        if (stackblitz && pre.getAttribute(DATA_STACKBLITZ) === 'true') {
-          actions.push({
-            title: 'Open in StackBlitz',
-            icon: STACKBLITZ_SVG,
-            run: (snippet) => openInStackblitz(snippet, stackblitz),
-          })
-        }
+        const context: NgeMarkdownCodeActionContext = { pre: pre as HTMLElement, code: raw, language, filename }
+        const actions = actionProviders
+          .map((provider) => provider(context))
+          .filter((action): action is CodeAction => action != null)
 
         // Same chrome (filename tab, copy, download, extra actions) whatever the
         // colorizing backend.

--- a/projects/nge/markdown/src/contributions/nge-markdown-shiki.ts
+++ b/projects/nge/markdown/src/contributions/nge-markdown-shiki.ts
@@ -35,6 +35,16 @@ export const NGE_MARKDOWN_SHIKI_DEFAULT_LANGS = [
 ]
 
 /**
+ * Loads shiki through a non-literal specifier so bundlers treat it as an
+ * optional runtime import: apps that never call `withShiki()` build without the
+ * peer installed, while apps that do get it bundled as a lazy chunk on first use.
+ */
+async function loadShiki(): Promise<typeof import('shiki')> {
+  const moduleName = 'shiki'
+  return import(/* @vite-ignore */ moduleName) as Promise<typeof import('shiki')>
+}
+
+/**
  * Loads shiki and the configured grammars ahead of the first render, so every
  * `codeToHtml` call during server rendering resolves without async grammar
  * fetches. Called by `withShiki` through an app initializer on the server.
@@ -42,7 +52,7 @@ export const NGE_MARKDOWN_SHIKI_DEFAULT_LANGS = [
 export async function preloadShiki(options: NgeMarkdownShikiOptions = {}): Promise<void> {
   const themes = options.themes ?? { light: 'github-light', dark: 'github-dark' }
   const langs = options.langs ?? NGE_MARKDOWN_SHIKI_DEFAULT_LANGS
-  const { codeToHtml } = await import('shiki')
+  const { codeToHtml } = await loadShiki()
   await Promise.all(langs.map((lang) => codeToHtml('', { lang, themes, defaultColor: false }).catch(() => undefined)))
 }
 
@@ -66,7 +76,7 @@ export function shikiHighlighterService(options: NgeMarkdownShikiOptions = {}): 
         return
       }
 
-      const { codeToHtml } = await import('shiki')
+      const { codeToHtml } = await loadShiki()
       let html: string
       try {
         html = await codeToHtml(code.textContent ?? '', {

--- a/projects/nge/markdown/src/contributions/nge-markdown-stackblitz.spec.ts
+++ b/projects/nge/markdown/src/contributions/nge-markdown-stackblitz.spec.ts
@@ -1,4 +1,5 @@
-import { buildStackblitzProject } from './nge-markdown-stackblitz'
+import { DATA_STACKBLITZ, NgeMarkdownCodeActionContext } from './nge-markdown-highlighter'
+import { buildStackblitzProject, stackblitzCodeActionProvider } from './nge-markdown-stackblitz'
 
 describe('buildStackblitzProject', () => {
   const base = {
@@ -33,5 +34,25 @@ describe('buildStackblitzProject', () => {
 
     expect(project.template).toBe('typescript')
     expect(openFile).toBe('index.html')
+  })
+})
+
+describe('stackblitzCodeActionProvider', () => {
+  const provider = stackblitzCodeActionProvider({ file: 'src/main.ts' })
+  const context = (stackblitz: string | null): NgeMarkdownCodeActionContext => ({
+    pre: { getAttribute: (name: string) => (name === DATA_STACKBLITZ ? stackblitz : null) } as unknown as HTMLElement,
+    code: 'const x = 1',
+    language: 'ts',
+  })
+
+  it('adds the action to blocks flagged with the stackblitz fence keyword', () => {
+    const action = provider(context('true'))
+
+    expect(action?.title).toBe('Open in StackBlitz')
+    expect(typeof action?.run).toBe('function')
+  })
+
+  it('skips blocks without the flag', () => {
+    expect(provider(context(null))).toBeNull()
   })
 })

--- a/projects/nge/markdown/src/contributions/nge-markdown-stackblitz.ts
+++ b/projects/nge/markdown/src/contributions/nge-markdown-stackblitz.ts
@@ -1,4 +1,7 @@
-import { InjectionToken } from '@angular/core'
+import { DATA_STACKBLITZ, NgeMarkdownCodeActionProvider } from './nge-markdown-highlighter'
+
+const STACKBLITZ_SVG =
+  '<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M10.5 13.5H4.5L14 2l-.5 8.5h6L10 22z"/></svg>'
 
 /**
  * Options for opening fenced code in [StackBlitz](https://stackblitz.com). The
@@ -55,13 +58,28 @@ export function buildStackblitzProject(code: string, options: NgeMarkdownStackbl
   }
 }
 
-/** Opens the snippet in StackBlitz. Loads the SDK lazily, so it never ships in the initial bundle. */
+/**
+ * Opens the snippet in StackBlitz. The SDK is loaded through a non-literal
+ * specifier so bundlers treat `@stackblitz/sdk` as an optional runtime import:
+ * apps that never call `withStackblitz()` build without the peer installed,
+ * instead of failing to resolve it at bundle time.
+ */
 export async function openInStackblitz(code: string, options: NgeMarkdownStackblitzOptions): Promise<void> {
   const { project, openFile } = buildStackblitzProject(code, options)
-  const sdk = (await import('@stackblitz/sdk')).default
+  const moduleName = '@stackblitz/sdk'
+  const sdk = (await import(/* @vite-ignore */ moduleName)).default
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sdk.openProject(project as any, { openFile, newWindow: true })
 }
 
-/** Set with `withStackblitz()` to enable the "Open in StackBlitz" code-block action. */
-export const NGE_MARKDOWN_STACKBLITZ = new InjectionToken<NgeMarkdownStackblitzOptions>('NGE_MARKDOWN_STACKBLITZ')
+/**
+ * The "Open in StackBlitz" toolbar action, added to blocks flagged with the
+ * `stackblitz` fence keyword. Lives here rather than in the highlighter so the
+ * StackBlitz SDK stays out of the module graph until `withStackblitz()` is used.
+ */
+export function stackblitzCodeActionProvider(options: NgeMarkdownStackblitzOptions): NgeMarkdownCodeActionProvider {
+  return ({ pre }) =>
+    pre.getAttribute(DATA_STACKBLITZ) === 'true'
+      ? { title: 'Open in StackBlitz', icon: STACKBLITZ_SVG, run: (snippet) => openInStackblitz(snippet, options) }
+      : null
+}

--- a/projects/nge/markdown/src/nge-markdown.providers.ts
+++ b/projects/nge/markdown/src/nge-markdown.providers.ts
@@ -15,13 +15,14 @@ import {
   NgeMarkdownEmojiOptions,
 } from './contributions/nge-markdown-emoji'
 import {
+  NGE_MARKDOWN_CODE_ACTIONS,
   NGE_MARKDOWN_HIGHLIGHTER_SERVICE,
   NgeMarkdownHighlighter,
   monacoHighlighterService,
 } from './contributions/nge-markdown-highlighter'
 import { NgeMarkdownIcons } from './contributions/nge-markdown-icons'
 import { NgeMarkdownShikiOptions, preloadShiki, shikiHighlighterService } from './contributions/nge-markdown-shiki'
-import { NGE_MARKDOWN_STACKBLITZ, NgeMarkdownStackblitzOptions } from './contributions/nge-markdown-stackblitz'
+import { NgeMarkdownStackblitzOptions, stackblitzCodeActionProvider } from './contributions/nge-markdown-stackblitz'
 import {
   NGE_MARKDOWN_KATEX_OPTIONS,
   NgeMarkdownKatex,
@@ -159,7 +160,9 @@ export function withShiki(options?: NgeMarkdownShikiOptions): NgeMarkdownFeature
  * set it up. Requires the optional `@stackblitz/sdk` peer dependency.
  */
 export function withStackblitz(options: NgeMarkdownStackblitzOptions): NgeMarkdownFeature {
-  return { providers: [{ provide: NGE_MARKDOWN_STACKBLITZ, useValue: options }] }
+  return {
+    providers: [{ provide: NGE_MARKDOWN_CODE_ACTIONS, multi: true, useValue: stackblitzCodeActionProvider(options) }],
+  }
 }
 
 function contribution(type: Type<NgeMarkdownContribution>): Provider {


### PR DESCRIPTION
Fix 1 : `ng add` survives Nx
`schematics/ng-add/index.ts` - the old try/catch only guarded rule construction; addRootProvider fails on execution, so the error escaped and aborted the whole schematic. Now the rule runs inside the guard via callRule (awaited through a plain subscribe to dodge the two rxjs copies the devkit ships). On failure it warns and falls back to the printed instructions, so scaffolding + the docs target + guidance still land. New mock-free test reproduces the crash class (build target the utility rejects) and asserts ng-add completes.

Fix 2 : `withShiki` no longer forces `@stackblitz/sdk`
Two parts, because the first alone wasn't enough:

Decoupled the highlighter from the `stackblitz` module via a new `NGE_MARKDOWN_CODE_ACTIONS` multi-token (`highlighter`). `withStackblitz` now contributes its action through that token (providers), [nge-markdown-stackblitz.ts) - the highlighter no longer imports the stackblitz module at all.
Non-literal specifier for the SDK import. Decoupling wasn't sufficient: esbuild eagerly resolves every literal import() in a reachable module, and openInStackblitz lives in the same markdown FESM as withShiki. A non-literal sp