### PR TITLE
fix(doc): do not require typedoc when the api option is omitted

### DIFF
--- a/projects/nge/doc/builders/docs/schema.ts
+++ b/projects/nge/doc/builders/docs/schema.ts
@@ -18,10 +18,14 @@ export interface DocsBuilderOptions {
   llms?: boolean
   /** Emit `search.json` (the content index). Default: true. */
   search?: boolean
-  /** Generate an API reference (needs the optional `typedoc` dependency). */
+  /**
+   * Generate an API reference (needs the optional `typedoc` dependency). The
+   * Angular builder schema materializes this as `{}` when omitted, so the API
+   * build only runs when `entryPoints` are actually provided.
+   */
   api?: {
     /** Entry point source files typedoc reads, e.g. `["projects/lib/src/index.ts"]`. */
-    entryPoints: string[]
+    entryPoints?: string[]
     /** tsconfig used to resolve types. Default: the nearest `tsconfig.json`. */
     tsconfig?: string
   }

--- a/projects/nge/doc/compiler/build.spec.ts
+++ b/projects/nge/doc/compiler/build.spec.ts
@@ -51,6 +51,15 @@ describe('buildDocs', () => {
     expect(Object.keys(written).filter((path) => path.endsWith('.md'))).toEqual([])
   })
 
+  it('ignores an empty api option (the builder schema materializes api: {} when omitted)', () => {
+    const { writer } = memWriter()
+    const fs = memFs({ 'docs/index.md': '# Home' })
+
+    // Without entryPoints there is nothing to generate; requiring typedoc here
+    // would break every docs site that does not want an API reference.
+    expect(() => buildDocs({ dir: 'docs', meta, outDir: 'out', api: {}, fs, writer })).not.toThrow()
+  })
+
   it('emits the AI/SEO files only when a siteUrl is given, and honors the opt-out flags', () => {
     const files = { 'docs/index.md': '# Home', 'docs/guide.md': '# Guide' }
 

--- a/projects/nge/doc/compiler/build.ts
+++ b/projects/nge/doc/compiler/build.ts
@@ -41,8 +41,11 @@ export interface BuildDocsOptions {
   llms?: boolean
   /** Emit `search.json` (the content index) next to the manifest. Default: true. */
   search?: boolean
-  /** Generate an API reference from TypeScript sources under `<dir>/api`. Off when absent. */
-  api?: Pick<ApiDocsOptions, 'entryPoints' | 'tsconfig'>
+  /**
+   * Generate an API reference from TypeScript sources under `<dir>/api`. Off when
+   * absent or without entryPoints (the Angular builder schema materializes `{}`).
+   */
+  api?: Partial<Pick<ApiDocsOptions, 'entryPoints' | 'tsconfig'>>
   fs?: DocFs
   writer?: DocFsWriter
   /** Source-control reader for `lastUpdated`. Default: the local git CLI. */
@@ -61,9 +64,15 @@ export function buildDocs(options: BuildDocsOptions): NgeDocManifest {
   const writer = options.writer ?? nodeFsWriter
 
   // Generate the API pages first, so the scan below picks them up as normal pages.
-  if (options.api) {
+  // Guard on entryPoints, not just `api`: the Angular builder schema materializes
+  // an empty `api: {}` when the option is omitted, and an API build without entry
+  // points has nothing to read anyway.
+  if (options.api?.entryPoints?.length) {
     const basePath = `${options.meta.root.replace(/\/+$/, '')}/api`
-    buildApiDocs({ ...options.api, dir: join(options.dir, 'api'), basePath }, writer)
+    buildApiDocs(
+      { entryPoints: options.api.entryPoints, tsconfig: options.api.tsconfig, dir: join(options.dir, 'api'), basePath },
+      writer
+    )
   }
 
   const manifest = compileDocs({ dir: options.dir, meta: options.meta, fs, git: options.git ?? nodeGit })


### PR DESCRIPTION
### Reported

`[nge-doc]: the api option needs typedoc. Install it with npm i -D typedoc, or remove api from the docs builder options.` on an app whose `docs` builder options do **not** include `api`:

```json
"docs": {
  "builder": "@cisstech/nge:docs",
  "options": { "publicDir": "public", "root": "/docs", "name": "toto" }
}
```

### Root cause

The Angular builder schema (devkit) materializes `type: object` options as `{}` when omitted, so `options.api` was always truthy. The builder entered the API branch and demanded typedoc, breaking every docs site that does not want an API reference.

### Fix

- Guard the API build on `api.entryPoints` (an API build without entry points has nothing to read anyway), so an empty `api: {}` is ignored.
- Relax the `api` types to `Partial<...>` / optional `entryPoints` to match what the builder actually passes.

Verified end to end: the docs builder now runs with no `api` and no typedoc installed. Added a regression test for the empty-`api` case; 110 doc tests pass.