### PR TITLE
fix(doc): hold pending tasks through route resolution for SSR

### DIFF
--- a/projects/nge/doc/builders/docs/schema.ts
+++ b/projects/nge/doc/builders/docs/schema.ts
@@ -18,10 +18,14 @@ export interface DocsBuilderOptions {
   llms?: boolean
   /** Emit `search.json` (the content index). Default: true. */
   search?: boolean
-  /** Generate an API reference (needs the optional `typedoc` dependency). */
+  /**
+   * Generate an API reference (needs the optional `typedoc` dependency). The
+   * Angular builder schema materializes this as `{}` when omitted, so the API
+   * build only runs when `entryPoints` are actually provided.
+   */
   api?: {
     /** Entry point source files typedoc reads, e.g. `["projects/lib/src/index.ts"]`. */
-    entryPoints: string[]
+    entryPoints?: string[]
     /** tsconfig used to resolve types. Default: the nearest `tsconfig.json`. */
     tsconfig?: string
   }

--- a/projects/nge/doc/compiler/build.spec.ts
+++ b/projects/nge/doc/compiler/build.spec.ts
@@ -51,6 +51,15 @@ describe('buildDocs', () => {
     expect(Object.keys(written).filter((path) => path.endsWith('.md'))).toEqual([])
   })
 
+  it('ignores an empty api option (the builder schema materializes api: {} when omitted)', () => {
+    const { writer } = memWriter()
+    const fs = memFs({ 'docs/index.md': '# Home' })
+
+    // Without entryPoints there is nothing to generate; requiring typedoc here
+    // would break every docs site that does not want an API reference.
+    expect(() => buildDocs({ dir: 'docs', meta, outDir: 'out', api: {}, fs, writer })).not.toThrow()
+  })
+
   it('emits the AI/SEO files only when a siteUrl is given, and honors the opt-out flags', () => {
     const files = { 'docs/index.md': '# Home', 'docs/guide.md': '# Guide' }
 

--- a/projects/nge/doc/compiler/build.ts
+++ b/projects/nge/doc/compiler/build.ts
@@ -41,8 +41,11 @@ export interface BuildDocsOptions {
   llms?: boolean
   /** Emit `search.json` (the content index) next to the manifest. Default: true. */
   search?: boolean
-  /** Generate an API reference from TypeScript sources under `<dir>/api`. Off when absent. */
-  api?: Pick<ApiDocsOptions, 'entryPoints' | 'tsconfig'>
+  /**
+   * Generate an API reference from TypeScript sources under `<dir>/api`. Off when
+   * absent or without entryPoints (the Angular builder schema materializes `{}`).
+   */
+  api?: Partial<Pick<ApiDocsOptions, 'entryPoints' | 'tsconfig'>>
   fs?: DocFs
   writer?: DocFsWriter
   /** Source-control reader for `lastUpdated`. Default: the local git CLI. */
@@ -61,9 +64,15 @@ export function buildDocs(options: BuildDocsOptions): NgeDocManifest {
   const writer = options.writer ?? nodeFsWriter
 
   // Generate the API pages first, so the scan below picks them up as normal pages.
-  if (options.api) {
+  // Guard on entryPoints, not just `api`: the Angular builder schema materializes
+  // an empty `api: {}` when the option is omitted, and an API build without entry
+  // points has nothing to read anyway.
+  if (options.api?.entryPoints?.length) {
     const basePath = `${options.meta.root.replace(/\/+$/, '')}/api`
-    buildApiDocs({ ...options.api, dir: join(options.dir, 'api'), basePath }, writer)
+    buildApiDocs(
+      { entryPoints: options.api.entryPoints, tsconfig: options.api.tsconfig, dir: join(options.dir, 'api'), basePath },
+      writer
+    )
   }
 
   const manifest = compileDocs({ dir: options.dir, meta: options.meta, fs, git: options.git ?? nodeGit })

--- a/projects/nge/doc/src/core/nge-doc.service.ts
+++ b/projects/nge/doc/src/core/nge-doc.service.ts
@@ -1,5 +1,5 @@
 import { Location } from '@angular/common'
-import { Injectable, Injector, OnDestroy, computed, inject, signal } from '@angular/core'
+import { Injectable, Injector, OnDestroy, PendingTasks, computed, inject, signal } from '@angular/core'
 import { toSignal } from '@angular/core/rxjs-interop'
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router'
 import { BehaviorSubject, Subscription } from 'rxjs'
@@ -31,6 +31,7 @@ export class NgeDocService implements OnDestroy {
   private readonly router = inject(Router)
   private readonly injector = inject(Injector)
   private readonly location = inject(Location)
+  private readonly pendingTasks = inject(PendingTasks)
   private readonly activatedRoute = inject(ActivatedRoute)
   private readonly seoService = inject(NgeDocSeoService)
   private readonly sitesLoader = inject(NgeDocSitesLoader)
@@ -148,22 +149,40 @@ export class NgeDocService implements OnDestroy {
    * into a manifest, flattens it for prev/next, and hands the set to search.
    */
   async setup(): Promise<void> {
-    this.reset()
+    // Hold application stability across the async setup and the first route
+    // resolution, so server-side rendering does not reach a stable state (and
+    // tear the injector down) before the documentation content has rendered.
+    const removePendingTask = this.pendingTasks.add()
+    try {
+      this.reset()
 
-    this.manifests = await this.sitesLoader.load(this.activatedRoute.snapshot.data)
+      this.manifests = await this.sitesLoader.load(this.activatedRoute.snapshot.data)
 
-    this.routable = this.manifests.flatMap((manifest) => flattenPages(manifest.pages))
-    this.sites.set(this.manifests.map((manifest) => manifest.meta))
-    await this.searchProvider.index(this.manifests)
+      this.routable = this.manifests.flatMap((manifest) => flattenPages(manifest.pages))
+      this.sites.set(this.manifests.map((manifest) => manifest.meta))
+      await this.searchProvider.index(this.manifests)
 
-    this.subscriptions.push(
-      this.router.events.pipe(filter((e) => e instanceof NavigationEnd)).subscribe(this.onChangeRoute.bind(this))
-    )
+      this.subscriptions.push(
+        this.router.events.pipe(filter((e) => e instanceof NavigationEnd)).subscribe(this.onChangeRoute.bind(this))
+      )
 
-    this.onChangeRoute()
+      await this.onChangeRoute()
+    } finally {
+      removePendingTask()
+    }
   }
 
+  /** Keeps the app unstable while the route (and any redirect it triggers) resolves. */
   private async onChangeRoute(): Promise<void> {
+    const removePendingTask = this.pendingTasks.add()
+    try {
+      await this.resolveRoute()
+    } finally {
+      removePendingTask()
+    }
+  }
+
+  private async resolveRoute(): Promise<void> {
     if (!this.manifests.length) {
       return
     }
@@ -206,7 +225,9 @@ export class NgeDocService implements OnDestroy {
     if (!currLink) {
       const firstPage = links.find((link) => !link.separator && link.href)
       if (firstPage?.href) {
-        this.router.navigateByUrl(firstPage.href, { replaceUrl: true })
+        // Awaited so the pending task spans the redirect; server rendering waits
+        // for the target page instead of settling on the empty site root.
+        await this.router.navigateByUrl(firstPage.href, { replaceUrl: true })
       }
       return
     }
@@ -215,7 +236,7 @@ export class NgeDocService implements OnDestroy {
     if (!currLink.renderer && currLink.children?.length) {
       const firstChild = currLink.children.find((child) => child.href)
       if (firstChild?.href) {
-        this.router.navigateByUrl(firstChild.href, { replaceUrl: true })
+        await this.router.navigateByUrl(firstChild.href, { replaceUrl: true })
       }
       return
     }

--- a/projects/nge/doc/src/ui/renderer/renderer.component.ts
+++ b/projects/nge/doc/src/ui/renderer/renderer.component.ts
@@ -56,6 +56,9 @@ interface MarkdownRenderSource {
 })
 export class NgeDocRendererComponent implements OnInit, OnDestroy {
   private readonly injector = inject(Injector)
+  // Resolved eagerly: a late injector.get after an await can hit a torn-down
+  // injector during server rendering (NG0205).
+  private readonly assets = inject(NgeDocAssets)
   private readonly renderers = inject(NGE_DOC_RENDERERS)
   private readonly docService = inject(NgeDocService)
   private readonly compilerService = inject(CompilerService)
@@ -249,7 +252,7 @@ export class NgeDocRendererComponent implements OnInit, OnDestroy {
       if (!data.includes('\n')) {
         // if data does not include at least two lines then it's an url
         inputs = {
-          data: await this.injector.get(NgeDocAssets).text(data),
+          data: await this.assets.text(data),
         }
       }
 


### PR DESCRIPTION
### Reported

`RuntimeError: NG0205: Injector has already been destroyed` during server-side rendering of a docs page, in `NgeDocRendererComponent.renderMarkdown` -> `createInputs` -> `injector.get`, on a fresh SSR app (`outputMode: server`).

### Root cause

`NgeDocService.setup()` loads manifests and indexes search, then `onChangeRoute()` resolves the route and can trigger a redirect (`navigateByUrl`). None of that async work held a pending task, and the redirect was not awaited. Under SSR this leaves a stability gap: the app can reach stability and its injector be torn down before the doc content renders, so the renderer's async render runs against a destroyed injector (NG0205). zone.js masks it (the zone stays unstable during macrotasks); zoneless apps expose it.

### Fix

- Hold a `PendingTasks` task across `setup()` and each route resolution, and `await` the redirect navigations, so the app stays unstable until the content is rendered.
- Resolve `NgeDocAssets` eagerly in the renderer instead of a late `injector.get` after an `await` (defence in depth against a torn-down injector).
